### PR TITLE
Ch13735/add active device event to reference dialer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-reference-dialer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Amazon connect reference dialer application by CALLSTATS I/O",
   "main": "src/server/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-reference-dialer",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Amazon connect reference dialer application by CALLSTATS I/O",
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/api/csioHandler.js
+++ b/src/client/api/csioHandler.js
@@ -7,6 +7,7 @@ import databaseManager from './databaseManager';
 import {
   getRandomInt
 } from './../utils/acutils';
+import mediaManager from './mediaManager';
 
 const appId = APP_ID || WEB_PACK_APP_ID;
 const appSecret = APP_SECRET || WEB_PACK_APP_SECRET;
@@ -136,7 +137,7 @@ class CSIOHandler {
       siteID: this.getRandomSiteId(),
       enableJabraCollection: enableJabraCollection
     };
-    console.log('JabraCollection' + ENABLE_JABRA_COLLECTION)
+    console.log('JabraCollection' + ENABLE_JABRA_COLLECTION);
     if (this.callstatsac) {
       this.callstatsac = undefined;
     }
@@ -185,6 +186,17 @@ class CSIOHandler {
     CallstatsAmazonShim.sendUserFeedback(feedback, msg => {
       console.warn('on submitted rating ', msg);
     });
+  }
+
+  sendActiveDeviceList () {
+    mediaManager.getDefaultOrPreferredAudioInputDevice()
+      .then(activeAudioDevice => {
+        const eventData = {
+          deviceList: [activeAudioDevice]
+        };
+        CallstatsAmazonShim.sendFabricEvent(this.callstatsac.fabricEvent.activeDeviceList, eventData);
+      })
+      .catch(() => {});
   }
 }
 

--- a/src/client/api/eventhandler.js
+++ b/src/client/api/eventhandler.js
@@ -231,6 +231,8 @@ class EventHandler {
         if (remoteStream) {
           this.dispatch(onRemoteStream(remoteStream));
         }
+        // send active device list
+        csioHandler.sendActiveDeviceList();
       });
     }
   }

--- a/src/client/container/audiolabelview/localaudiolevel.js
+++ b/src/client/container/audiolabelview/localaudiolevel.js
@@ -26,7 +26,7 @@ class LocalAudiolevel extends React.Component {
   async _fetchMediaInternals (mediaRetryCount = 0) {
     let now = (new Date()).getTime();
     if (now - this.lastRetry < MEDIA_RETRY_INTERVAL_MS) {
-      throw new Error('Already tring to fetch media');
+      throw new Error('Already trying to fetch media');
     }
     let selectedDevice = await mediaManager.getDefaultOrPreferredAudioInputDevice();
     // console.warn('~fetchMedia', 'trying to fetch local media', mediaRetryCount, selectedDevice);

--- a/src/client/container/footer/components/version.js
+++ b/src/client/container/footer/components/version.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import versionIcon from '../../../res/images/fa-version.svg';
+
+const Version = ({ divClass = '', linkClass = '', style = {}, onClickHandler }) => (
+  <div className={divClass}>
+    <a className={linkClass}
+		   style={style}
+		   onClick={onClickHandler}
+    > <img src={versionIcon}/> {`Dialer v${window.CS_VERSION}` }</a>
+  </div>
+);
+
+Version.propTypes = {
+  divClass: PropTypes.string,
+  linkClass: PropTypes.string,
+  style: PropTypes.object,
+  onClickHandler: PropTypes.func.isRequired
+};
+
+export default Version;

--- a/src/client/container/settingsview/footer.js
+++ b/src/client/container/settingsview/footer.js
@@ -11,6 +11,7 @@ import ReportACall from '../footer/components/reportcall';
 import DownloadLogs from '../footer/components/downloadlogs';
 import ConnectivityCheck from '../footer/components/connectivitycheck';
 import Language from '../footer/components/language';
+import Version from '../footer/components/version';
 
 import acManager from '../../api/acManager';
 
@@ -41,9 +42,9 @@ const FooterStyle = {
     style: { cursor: 'pointer', color: '#3885de', fontFamily: 'AmazonEmber', fontSize: '14px' }
   },
   version: {
-    divClass: 'col-12 p-0',
-    pClass: 'text-right',
-    style: { fontSize: '11px', fontStyle: 'italic' }
+    divClass: 'col-6 p-0',
+    linkClass: 'btn text-left disabled',
+    style: { cursor: 'pointer', color: '#3885de', fontFamily: 'AmazonEmber', fontSize: '14px' }
   }
 };
 
@@ -65,14 +66,11 @@ const Footer = ({ requestReportACallIssue, requestConnectivityCheck }) => (
         style={FooterStyle.connectivityCheck.style}
         onClickHandler={requestConnectivityCheck} />
 
-      <Language divClass={FooterStyle.language.divClass}
-        linkClass={FooterStyle.language.linkClass}
-        style={FooterStyle.language.style}
+      <Version divClass={FooterStyle.version.divClass}
+        linkClass={FooterStyle.version.linkClass}
+        style={FooterStyle.version.style}
         onClickHandler={() => true} />
 
-      <div class={FooterStyle.version.divClass}>
-        <p class={FooterStyle.version.pClass} style={FooterStyle.version.style}>callstats dialer v{window.CS_VERSION}</p>
-      </div>
     </div>
   </div>
 );

--- a/src/client/res/images/fa-version.svg
+++ b/src/client/res/images/fa-version.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path fill="#3885DE" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/>
+</svg>


### PR DESCRIPTION
**Add active device event to reference dialer**

https://app.clubhouse.io/callstatsio/story/13735/add-active-device-event-to-reference-dialer

Add active device event feature in amazon connect dialer. It will send the current active audio device and thus you can see your currently active device in callstats connection timeline dashboard